### PR TITLE
make terminating char ; optional

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -276,4 +276,23 @@ mod tests {
             ]
         )
     }
+
+    #[test]
+    fn can_parse_graph_without_semicolon() {
+        let input = "digraph {
+            1 
+            2
+            1 -> 2
+        }";
+        let (rest, graph) = parse(input);
+        assert_eq!(rest, "");
+        assert_eq!(
+            graph.stmt,
+            vec![
+                Stmt::Node(String::from("1"), vec![]),
+                Stmt::Node(String::from("2"), vec![]),
+                Stmt::Edge(String::from("1"), String::from("2"), vec![]),
+            ]
+        )
+    }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -65,7 +65,7 @@ fn parse_statement(is_directed: bool) -> impl Fn(&str) -> IResult<&str, Stmt> {
         let (s, _) = multispace0(s)?;
         let (s, stmt) = alt((parse_edge_statement(is_directed), parse_node_statement))(s)?;
         let (s, _) = multispace0(s)?;
-        let (s, _) = char(';')(s)?;
+        let (s, _) = opt(char(';'))(s)?;
         Ok((s, stmt))
     }
 }


### PR DESCRIPTION
What do you think about making terminating char `;` optional like this? I have 0 experience with `nom` but I found your library potentially useful for a small project of mine.